### PR TITLE
fix incorrect Windows-specific behaviour

### DIFF
--- a/ignore.go
+++ b/ignore.go
@@ -55,6 +55,7 @@ import (
     "strings"
     "regexp"
     "io/ioutil"
+    "os"
 )
 
 // An IgnoreParser is an interface which exposes two methods:
@@ -75,6 +76,9 @@ type GitIgnore struct {
 // This function pretty much attempts to mimic the parsing rules
 // listed above at the start of this file
 func getPatternFromLine(line string) (*regexp.Regexp, bool) {
+    // Trim OS-specific carriage returns.
+    line = strings.TrimRight(line, "\r")
+
     // Strip comments [Rule 2]
     if regexp.MustCompile(`^#`).MatchString(line) { return nil, false }
 
@@ -156,6 +160,9 @@ func CompileIgnoreFile(fpath string) (*GitIgnore, error) {
 // It returns true if the given GitIgnore structure would target a given
 // path string "f"
 func (g GitIgnore) MatchesPath(f string) bool {
+    // Replace OS-specific path separator.
+    f = strings.Replace(f, string(os.PathSeparator), "/", -1)
+
     matchesPath := false
     for idx, pattern := range g.patterns {
         if pattern.MatchString(f) {

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -11,6 +11,7 @@ import (
     "testing"
 
     "github.com/stretchr/testify/assert"
+    "runtime"
 )
 
 const (
@@ -272,11 +273,13 @@ func TestCompileIgnoreLines_CarriageReturn(test *testing.T) {
 }
 
 func TestCompileIgnoreLines_WindowsPath(test *testing.T) {
+    if runtime.GOOS != "windows" {
+        return
+    }
     lines := []string{"abc/def", "a/b/c", "b"}
     object, error := CompileIgnoreLines(lines...)
     assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
 
     assert.Equal(test, true,  object.MatchesPath("abc\\def\\child"), "abc\\def\\child should match")
     assert.Equal(test, true,  object.MatchesPath("a\\b\\c\\d"),       "a\\b\\c\\d should match")
-
 }

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -257,3 +257,26 @@ func TestCompileIgnoreLines_CheckNestedDotFiles(test *testing.T) {
     assert.Equal(test, true,  object.MatchesPath("external/barfoo/.gitignore"), "external/barfoo/.gitignore")
     assert.Equal(test, true,  object.MatchesPath("external/barfoo/.bower.json"), "external/barfoo/.bower.json")
 }
+
+func TestCompileIgnoreLines_CarriageReturn(test *testing.T) {
+    lines := []string{"abc/def\r", "a/b/c\r", "b\r"}
+    object, error := CompileIgnoreLines(lines...)
+    assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
+
+    assert.Equal(test, true,  object.MatchesPath("abc/def/child"), "abc/def/child should match")
+    assert.Equal(test, true,  object.MatchesPath("a/b/c/d"),       "a/b/c/d should match")
+
+    assert.Equal(test, false, object.MatchesPath("abc"), "abc should not match")
+    assert.Equal(test, false, object.MatchesPath("def"), "def should not match")
+    assert.Equal(test, false, object.MatchesPath("bd"),  "bd should not match")
+}
+
+func TestCompileIgnoreLines_WindowsPath(test *testing.T) {
+    lines := []string{"abc/def", "a/b/c", "b"}
+    object, error := CompileIgnoreLines(lines...)
+    assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
+
+    assert.Equal(test, true,  object.MatchesPath("abc\\def\\child"), "abc\\def\\child should match")
+    assert.Equal(test, true,  object.MatchesPath("a\\b\\c\\d"),       "a\\b\\c\\d should match")
+
+}


### PR DESCRIPTION
Fix Windows issues:
* "\r\n" as line endings
* "\" as path separator

Add simple (copy-pasted) tests.

