### PR TITLE
wildcard support for directories with preceding /

### DIFF
--- a/ignore.go
+++ b/ignore.go
@@ -52,145 +52,149 @@ The summarized version of the same has been copied here:
 package ignore
 
 import (
-    "strings"
-    "regexp"
-    "io/ioutil"
-    "os"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
 )
 
 // An IgnoreParser is an interface which exposes two methods:
 //   MatchesPath() - Returns true if the path is targeted by the patterns compiled in the GitIgnore structure
 type IgnoreParser interface {
-    IncludesPath(f string) bool
-    IgnoresPath(f string)  bool
-    MatchesPath(f string) bool
+	IncludesPath(f string) bool
+	IgnoresPath(f string) bool
+	MatchesPath(f string) bool
 }
 
 // GitIgnore is a struct which contains a slice of regexp.Regexp
 // patterns
 type GitIgnore struct {
-    patterns []*regexp.Regexp   // List of regexp patterns which this ignore file applies
-    negate   []bool             // List of booleans which determine if the pattern is negated
+	patterns []*regexp.Regexp // List of regexp patterns which this ignore file applies
+	negate   []bool           // List of booleans which determine if the pattern is negated
 }
 
 // This function pretty much attempts to mimic the parsing rules
 // listed above at the start of this file
 func getPatternFromLine(line string) (*regexp.Regexp, bool) {
-    // Trim OS-specific carriage returns.
-    line = strings.TrimRight(line, "\r")
+	// Trim OS-specific carriage returns.
+	line = strings.TrimRight(line, "\r")
 
-    // Strip comments [Rule 2]
-    if strings.HasPrefix(line, `#`) { return nil, false }
+	// Strip comments [Rule 2]
+	if strings.HasPrefix(line, `#`) {
+		return nil, false
+	}
 
-    // Trim string [Rule 3]
-    // TODO: Handle [Rule 3], when the " " is escaped with a \
-    line = strings.Trim(line, " ")
+	// Trim string [Rule 3]
+	// TODO: Handle [Rule 3], when the " " is escaped with a \
+	line = strings.Trim(line, " ")
 
-    // Exit for no-ops and return nil which will prevent us from
-    // appending a pattern against this line
-    if line == "" { return nil, false }
+	// Exit for no-ops and return nil which will prevent us from
+	// appending a pattern against this line
+	if line == "" {
+		return nil, false
+	}
 
-    // TODO: Handle [Rule 4] which negates the match for patterns leading with "!"
-    negatePattern := false
-    if string(line[0]) == "!" {
-        negatePattern = true
-        line = line[1:]
-    }
+	// TODO: Handle [Rule 4] which negates the match for patterns leading with "!"
+	negatePattern := false
+	if line[0] == '!' {
+		negatePattern = true
+		line = line[1:]
+	}
 
-    // Handle [Rule 2, 4], when # or ! is escaped with a \
-    // Handle [Rule 4] once we tag negatePattern, strip the leading ! char
-    if regexp.MustCompile(`^(\#|\!)`).MatchString(line) {
-        line = line[1:]
-    }
+	// Handle [Rule 2, 4], when # or ! is escaped with a \
+	// Handle [Rule 4] once we tag negatePattern, strip the leading ! char
+	if regexp.MustCompile(`^(\#|\!)`).MatchString(line) {
+		line = line[1:]
+	}
 
-    // If we encounter a foo/*.blah in a folder, prepend the / char
-    if regexp.MustCompile(`([^\/+])/.*\*\.`).MatchString(line) {
-        line = "/" + line
-    }
+	// If we encounter a foo/*.blah in a folder, prepend the / char
+	if regexp.MustCompile(`([^\/+])/.*\*\.`).MatchString(line) && line[0] != '/' {
+		line = "/" + line
+	}
 
-    // Handle escaping the "." char
-    line = regexp.MustCompile(`\.`).ReplaceAllString(line, `\.`)
+	// Handle escaping the "." char
+	line = regexp.MustCompile(`\.`).ReplaceAllString(line, `\.`)
 
-    magicStar := "#$~"
+	magicStar := "#$~"
 
-    // Handle "/**/" usage
-    if strings.HasPrefix(line, "/**/") {
-        line = line[1:]
-    }
-    line = regexp.MustCompile(`/\*\*/`).ReplaceAllString(line, `(/|/.+/)`)
-    line = regexp.MustCompile(`\*\*/`).ReplaceAllString(line, `(|.` + magicStar + `/)`)
-    line = regexp.MustCompile(`/\*\*`).ReplaceAllString(line, `(|/.` + magicStar + `)`)
+	// Handle "/**/" usage
+	if strings.HasPrefix(line, "/**/") {
+		line = line[1:]
+	}
+	line = regexp.MustCompile(`/\*\*/`).ReplaceAllString(line, `(/|/.+/)`)
+	line = regexp.MustCompile(`\*\*/`).ReplaceAllString(line, `(|.`+magicStar+`/)`)
+	line = regexp.MustCompile(`/\*\*`).ReplaceAllString(line, `(|/.`+magicStar+`)`)
 
-    // Handle escaping the "*" char
-    line = regexp.MustCompile(`\\\*`).ReplaceAllString(line, `\` + magicStar)
-    line = regexp.MustCompile(`\*`).ReplaceAllString(line, `([^/]*)`)
+	// Handle escaping the "*" char
+	line = regexp.MustCompile(`\\\*`).ReplaceAllString(line, `\`+magicStar)
+	line = regexp.MustCompile(`\*`).ReplaceAllString(line, `([^/]*)`)
 
-    // Handle escaping the "?" char
-    line = strings.Replace(line, "?", `\?`, -1)
+	// Handle escaping the "?" char
+	line = strings.Replace(line, "?", `\?`, -1)
 
-    line = strings.Replace(line, magicStar, "*", -1)
+	line = strings.Replace(line, magicStar, "*", -1)
 
-    // Temporary regex
-    var expr = ""
-    if strings.HasSuffix(line, "/") {
-        expr = line + "(|.*)$"
-    } else {
-        expr = line + "(|/.*)$"
-    }
-    if strings.HasPrefix(expr, "/") {
-        expr = "^(|/)" + expr[1:]
-    } else {
-        expr = "^(|.*/)" + expr
-    }
-    pattern, _ := regexp.Compile(expr)
+	// Temporary regex
+	var expr = ""
+	if strings.HasSuffix(line, "/") {
+		expr = line + "(|.*)$"
+	} else {
+		expr = line + "(|/.*)$"
+	}
+	if strings.HasPrefix(expr, "/") {
+		expr = "^(|/)" + expr[1:]
+	} else {
+		expr = "^(|.*/)" + expr
+	}
+	pattern, _ := regexp.Compile(expr)
 
-    return pattern, negatePattern
+	return pattern, negatePattern
 }
 
 // Accepts a variadic set of strings, and returns a GitIgnore object which
 // converts and appends the lines in the input to regexp.Regexp patterns
 // held within the GitIgnore objects "patterns" field
 func CompileIgnoreLines(lines ...string) (*GitIgnore, error) {
-    g := new(GitIgnore)
-    for _, line := range lines {
-        pattern, negatePattern := getPatternFromLine(line)
-        if pattern != nil {
-            g.patterns = append(g.patterns, pattern)
-            g.negate = append(g.negate, negatePattern)
-        }
-    }
-    return g, nil
+	g := new(GitIgnore)
+	for _, line := range lines {
+		pattern, negatePattern := getPatternFromLine(line)
+		if pattern != nil {
+			g.patterns = append(g.patterns, pattern)
+			g.negate = append(g.negate, negatePattern)
+		}
+	}
+	return g, nil
 }
 
 // Accepts a ignore file as the input, parses the lines out of the file
 // and invokes the CompileIgnoreLines method
 func CompileIgnoreFile(fpath string) (*GitIgnore, error) {
-    buffer, error := ioutil.ReadFile(fpath)
-    if error == nil {
-        s := strings.Split(string(buffer), "\n")
-        return CompileIgnoreLines(s...)
-    }
-    return nil, error
+	buffer, error := ioutil.ReadFile(fpath)
+	if error == nil {
+		s := strings.Split(string(buffer), "\n")
+		return CompileIgnoreLines(s...)
+	}
+	return nil, error
 }
 
 // MatchesPath is an interface function for the IgnoreParser interface.
 // It returns true if the given GitIgnore structure would target a given
 // path string "f"
 func (g GitIgnore) MatchesPath(f string) bool {
-    // Replace OS-specific path separator.
-    f = strings.Replace(f, string(os.PathSeparator), "/", -1)
+	// Replace OS-specific path separator.
+	f = strings.Replace(f, string(os.PathSeparator), "/", -1)
 
-    matchesPath := false
-    for idx, pattern := range g.patterns {
-        if pattern.MatchString(f) {
-            // If this is a regular target (not negated with a gitignore exclude "!" etc)
-            if !g.negate[idx] {
-                matchesPath = true
-            // Negated pattern, and matchesPath is already set
-            } else if matchesPath {
-                matchesPath = false
-            }
-        }
-    }
-    return matchesPath
+	matchesPath := false
+	for idx, pattern := range g.patterns {
+		if pattern.MatchString(f) {
+			// If this is a regular target (not negated with a gitignore exclude "!" etc)
+			if !g.negate[idx] {
+				matchesPath = true
+				// Negated pattern, and matchesPath is already set
+			} else if matchesPath {
+				matchesPath = false
+			}
+		}
+	}
+	return matchesPath
 }

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -304,3 +304,18 @@ func TestWildCardFiles(test *testing.T) {
 	assert.Equal(test, false, object.MatchesPath("something/not/infoo/wat.wat"), "wat files should only be ignored in foo")
 	assert.Equal(test, false, object.MatchesPath("something/not/infoo/wat.txt"), "txt files should only be ignored in bar")
 }
+
+func TestPrecedingSlash(test *testing.T) {
+	gitIgnore := []string{"/foo", "bar/"}
+	object, err := CompileIgnoreLines(gitIgnore...)
+	assert.Nil(test, err, "error from CompileIgnoreLines should be nil")
+
+	assert.Equal(test, true, object.MatchesPath("foo/bar.wat"), "should ignore all files in foo - nonpreceding /")
+	assert.Equal(test, true, object.MatchesPath("/foo/something.txt"), "should ignore all files in foo - preceding /")
+
+	assert.Equal(test, true, object.MatchesPath("bar/something.txt"), "should ignore all files in bar - nonpreceding /")
+	assert.Equal(test, true, object.MatchesPath("/bar/somethingelse.go"), "should ignore all files in bar - preceding /")
+	assert.Equal(test, true, object.MatchesPath("/boo/something/bar/boo.txt"), "should block all files if bar is a sub directory")
+
+	assert.Equal(test, false, object.MatchesPath("something/foo/something.txt"), "should only ignore top level foo directories- not nested")
+}

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -2,110 +2,111 @@
 package ignore
 
 import (
-    "os"
+	"os"
 
-    "io/ioutil"
-    "path/filepath"
+	"io/ioutil"
+	"path/filepath"
 
-    "fmt"
-    "testing"
+	"fmt"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
-    "runtime"
+	"runtime"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
-    TEST_DIR = "test_fixtures"
+	TEST_DIR = "test_fixtures"
 )
 
 // Helper function to setup a test fixture dir and write to
 // it a file with the name "fname" and content "content"
 func writeFileToTestDir(fname, content string) {
-    testDirPath := "." + string(filepath.Separator) + TEST_DIR
-    testFilePath := testDirPath + string(filepath.Separator) + fname
+	testDirPath := "." + string(filepath.Separator) + TEST_DIR
+	testFilePath := testDirPath + string(filepath.Separator) + fname
 
-    _ = os.MkdirAll(testDirPath, 0755)
-    _ = ioutil.WriteFile(testFilePath, []byte(content), os.ModePerm)
+	_ = os.MkdirAll(testDirPath, 0755)
+	_ = ioutil.WriteFile(testFilePath, []byte(content), os.ModePerm)
 }
 
 func cleanupTestDir() {
-    _ = os.RemoveAll(fmt.Sprintf(".%s%s", string(filepath.Separator), TEST_DIR))
+	_ = os.RemoveAll(fmt.Sprintf(".%s%s", string(filepath.Separator), TEST_DIR))
 }
 
 // Validate "CompileIgnoreLines()"
 func TestCompileIgnoreLines(test *testing.T) {
-    lines := []string{"abc/def", "a/b/c", "b"}
-    object, error := CompileIgnoreLines(lines...)
-    assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
+	lines := []string{"abc/def", "a/b/c", "b"}
+	object, error := CompileIgnoreLines(lines...)
+	assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
 
-    // MatchesPath
-    // Paths which are targeted by the above "lines"
-    assert.Equal(test, true,  object.MatchesPath("abc/def/child"), "abc/def/child should match")
-    assert.Equal(test, true,  object.MatchesPath("a/b/c/d"),       "a/b/c/d should match")
+	// MatchesPath
+	// Paths which are targeted by the above "lines"
+	assert.Equal(test, true, object.MatchesPath("abc/def/child"), "abc/def/child should match")
+	assert.Equal(test, true, object.MatchesPath("a/b/c/d"), "a/b/c/d should match")
 
-    // Paths which are not targeted by the above "lines"
-    assert.Equal(test, false, object.MatchesPath("abc"), "abc should not match")
-    assert.Equal(test, false, object.MatchesPath("def"), "def should not match")
-    assert.Equal(test, false, object.MatchesPath("bd"),  "bd should not match")
+	// Paths which are not targeted by the above "lines"
+	assert.Equal(test, false, object.MatchesPath("abc"), "abc should not match")
+	assert.Equal(test, false, object.MatchesPath("def"), "def should not match")
+	assert.Equal(test, false, object.MatchesPath("bd"), "bd should not match")
 
-    object, error = CompileIgnoreLines("abc/def", "a/b/c", "b")
-    assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
+	object, error = CompileIgnoreLines("abc/def", "a/b/c", "b")
+	assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
 
-    // Paths which are targeted by the above "lines"
-    assert.Equal(test, true,  object.MatchesPath("abc/def/child"), "abc/def/child should match")
-    assert.Equal(test, true,  object.MatchesPath("a/b/c/d"),       "a/b/c/d should match")
+	// Paths which are targeted by the above "lines"
+	assert.Equal(test, true, object.MatchesPath("abc/def/child"), "abc/def/child should match")
+	assert.Equal(test, true, object.MatchesPath("a/b/c/d"), "a/b/c/d should match")
 
-    // Paths which are not targeted by the above "lines"
-    assert.Equal(test, false, object.MatchesPath("abc"), "abc should not match")
-    assert.Equal(test, false, object.MatchesPath("def"), "def should not match")
-    assert.Equal(test, false, object.MatchesPath("bd"),  "bd should not match")
+	// Paths which are not targeted by the above "lines"
+	assert.Equal(test, false, object.MatchesPath("abc"), "abc should not match")
+	assert.Equal(test, false, object.MatchesPath("def"), "def should not match")
+	assert.Equal(test, false, object.MatchesPath("bd"), "bd should not match")
 }
 
 // Validate the invalid files
 func TestCompileIgnoreFile_InvalidFile(test *testing.T) {
-    object, error := CompileIgnoreFile("./test_fixtures/invalid.file")
-    assert.Nil(test, object, "object should be nil")
-    assert.NotNil(test, error, "error should be unknown file / dir")
+	object, error := CompileIgnoreFile("./test_fixtures/invalid.file")
+	assert.Nil(test, object, "object should be nil")
+	assert.NotNil(test, error, "error should be unknown file / dir")
 }
 
 // Validate the an empty files
 func TestCompileIgnoreLines_EmptyFile(test *testing.T) {
-    writeFileToTestDir("test.gitignore", ``)
-    defer cleanupTestDir()
+	writeFileToTestDir("test.gitignore", ``)
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, false, object.MatchesPath("a"),       "should not match any path")
-    assert.Equal(test, false, object.MatchesPath("a/b"),     "should not match any path")
-    assert.Equal(test, false, object.MatchesPath(".foobar"), "should not match any path")
+	assert.Equal(test, false, object.MatchesPath("a"), "should not match any path")
+	assert.Equal(test, false, object.MatchesPath("a/b"), "should not match any path")
+	assert.Equal(test, false, object.MatchesPath(".foobar"), "should not match any path")
 }
 
 // Validate the correct handling of the negation operator "!"
 func TestCompileIgnoreLines_HandleIncludePattern(test *testing.T) {
-    writeFileToTestDir("test.gitignore", `
+	writeFileToTestDir("test.gitignore", `
 # exclude everything except directory foo/bar
 /*
 !/foo
 /foo/*
 !/foo/bar
 `)
-    defer cleanupTestDir()
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("a"),        "a should match")
-    assert.Equal(test, true,  object.MatchesPath("foo/baz"),  "foo/baz should match")
-    assert.Equal(test, false, object.MatchesPath("foo"),      "foo should not match")
-    assert.Equal(test, false, object.MatchesPath("/foo/bar"), "/foo/bar should not match")
+	assert.Equal(test, true, object.MatchesPath("a"), "a should match")
+	assert.Equal(test, true, object.MatchesPath("foo/baz"), "foo/baz should match")
+	assert.Equal(test, false, object.MatchesPath("foo"), "foo should not match")
+	assert.Equal(test, false, object.MatchesPath("/foo/bar"), "/foo/bar should not match")
 }
 
 // Validate the correct handling of comments and empty lines
 func TestCompileIgnoreLines_HandleSpaces(test *testing.T) {
-    writeFileToTestDir("test.gitignore", `
+	writeFileToTestDir("test.gitignore", `
 #
 # A comment
 
@@ -116,170 +117,190 @@ func TestCompileIgnoreLines_HandleSpaces(test *testing.T) {
 
 abc/def
 `)
-    defer cleanupTestDir()
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, 2, len(object.patterns), "should have two regex pattern")
-    assert.Equal(test, false, object.MatchesPath("abc/abc"), "/abc/abc should not match")
-    assert.Equal(test, true,  object.MatchesPath("abc/def"), "/abc/def should match")
+	assert.Equal(test, 2, len(object.patterns), "should have two regex pattern")
+	assert.Equal(test, false, object.MatchesPath("abc/abc"), "/abc/abc should not match")
+	assert.Equal(test, true, object.MatchesPath("abc/def"), "/abc/def should match")
 }
 
 // Validate the correct handling of leading / chars
 func TestCompileIgnoreLines_HandleLeadingSlash(test *testing.T) {
-    writeFileToTestDir("test.gitignore", `
+	writeFileToTestDir("test.gitignore", `
 /a/b/c
 d/e/f
 /g
 `)
-    defer cleanupTestDir()
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, 3, len(object.patterns), "should have 3 regex patterns")
-    assert.Equal(test, true,  object.MatchesPath("a/b/c"),   "a/b/c should match")
-    assert.Equal(test, true,  object.MatchesPath("a/b/c/d"), "a/b/c/d should match")
-    assert.Equal(test, true,  object.MatchesPath("d/e/f"),   "d/e/f should match")
-    assert.Equal(test, true,  object.MatchesPath("g"),       "g should match")
+	assert.Equal(test, 3, len(object.patterns), "should have 3 regex patterns")
+	assert.Equal(test, true, object.MatchesPath("a/b/c"), "a/b/c should match")
+	assert.Equal(test, true, object.MatchesPath("a/b/c/d"), "a/b/c/d should match")
+	assert.Equal(test, true, object.MatchesPath("d/e/f"), "d/e/f should match")
+	assert.Equal(test, true, object.MatchesPath("g"), "g should match")
 }
 
 // Validate the correct handling of files starting with # or !
 func TestCompileIgnoreLines_HandleLeadingSpecialChars(test *testing.T) {
-    writeFileToTestDir("test.gitignore", `
+	writeFileToTestDir("test.gitignore", `
 # Comment
 \#file.txt
 \!file.txt
 file.txt
 `)
-    defer cleanupTestDir()
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("#file.txt"),   "#file.txt should match")
-    assert.Equal(test, true,  object.MatchesPath("!file.txt"),   "!file.txt should match")
-    assert.Equal(test, true,  object.MatchesPath("a/!file.txt"), "a/!file.txt should match")
-    assert.Equal(test, true,  object.MatchesPath("file.txt"),    "file.txt should match")
-    assert.Equal(test, true,  object.MatchesPath("a/file.txt"),  "a/file.txt should match")
-    assert.Equal(test, false, object.MatchesPath("file2.txt"),   "file2.txt should not match")
+	assert.Equal(test, true, object.MatchesPath("#file.txt"), "#file.txt should match")
+	assert.Equal(test, true, object.MatchesPath("!file.txt"), "!file.txt should match")
+	assert.Equal(test, true, object.MatchesPath("a/!file.txt"), "a/!file.txt should match")
+	assert.Equal(test, true, object.MatchesPath("file.txt"), "file.txt should match")
+	assert.Equal(test, true, object.MatchesPath("a/file.txt"), "a/file.txt should match")
+	assert.Equal(test, false, object.MatchesPath("file2.txt"), "file2.txt should not match")
 
 }
 
 // Validate the correct handling matching files only within a given folder
 func TestCompileIgnoreLines_HandleAllFilesInDir(test *testing.T) {
-    writeFileToTestDir("test.gitignore", `
+	writeFileToTestDir("test.gitignore", `
 Documentation/*.html
 `)
-    defer cleanupTestDir()
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("Documentation/git.html"),             "Documentation/git.html should match")
-    assert.Equal(test, false, object.MatchesPath("Documentation/ppc/ppc.html"),         "Documentation/ppc/ppc.html should not match")
-    assert.Equal(test, false, object.MatchesPath("tools/perf/Documentation/perf.html"), "tools/perf/Documentation/perf.html should not match")
+	assert.Equal(test, true, object.MatchesPath("Documentation/git.html"), "Documentation/git.html should match")
+	assert.Equal(test, false, object.MatchesPath("Documentation/ppc/ppc.html"), "Documentation/ppc/ppc.html should not match")
+	assert.Equal(test, false, object.MatchesPath("tools/perf/Documentation/perf.html"), "tools/perf/Documentation/perf.html should not match")
 }
 
 // Validate the correct handling of "**"
 func TestCompileIgnoreLines_HandleDoubleStar(test *testing.T) {
-    writeFileToTestDir("test.gitignore", `
+	writeFileToTestDir("test.gitignore", `
 **/foo
 bar
 `)
-    defer cleanupTestDir()
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("foo"),     "foo should match")
-    assert.Equal(test, true,  object.MatchesPath("baz/foo"), "baz/foo should match")
-    assert.Equal(test, true,  object.MatchesPath("bar"),     "bar should match")
-    assert.Equal(test, true,  object.MatchesPath("baz/bar"), "baz/bar should match")
+	assert.Equal(test, true, object.MatchesPath("foo"), "foo should match")
+	assert.Equal(test, true, object.MatchesPath("baz/foo"), "baz/foo should match")
+	assert.Equal(test, true, object.MatchesPath("bar"), "bar should match")
+	assert.Equal(test, true, object.MatchesPath("baz/bar"), "baz/bar should match")
 }
 
 // Validate the correct handling of leading slash
 func TestCompileIgnoreLines_HandleLeadingSlashPath(test *testing.T) {
-    writeFileToTestDir("test.gitignore", `
+	writeFileToTestDir("test.gitignore", `
 /*.c
 `)
-    defer cleanupTestDir()
+	defer cleanupTestDir()
 
-    object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
-    assert.Nil(test, error, "error should be nil")
-    assert.NotNil(test, object, "object should not be nil")
+	object, error := CompileIgnoreFile("./test_fixtures/test.gitignore")
+	assert.Nil(test, error, "error should be nil")
+	assert.NotNil(test, object, "object should not be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("hello.c"),     "hello.c should match")
-    assert.Equal(test, false, object.MatchesPath("foo/hello.c"), "foo/hello.c should not match")
+	assert.Equal(test, true, object.MatchesPath("hello.c"), "hello.c should match")
+	assert.Equal(test, false, object.MatchesPath("foo/hello.c"), "foo/hello.c should not match")
 }
 
 func ExampleCompileIgnoreLines() {
-    ignoreObject, error := CompileIgnoreLines([]string{"node_modules", "*.out", "foo/*.c"}...)
-    if error != nil {
-        panic("Error when compiling ignore lines: " + error.Error())
-    }
+	ignoreObject, error := CompileIgnoreLines([]string{"node_modules", "*.out", "foo/*.c"}...)
+	if error != nil {
+		panic("Error when compiling ignore lines: " + error.Error())
+	}
 
-    // You can test the ignoreObject against various paths using the
-    // "MatchesPath()" interface method. This pretty much is up to
-    // the users interpretation. In the case of a ".gitignore" file,
-    // a "match" would indicate that a given path would be ignored.
-    fmt.Println(ignoreObject.MatchesPath("node_modules/test/foo.js"))
-    fmt.Println(ignoreObject.MatchesPath("node_modules2/test.out"))
-    fmt.Println(ignoreObject.MatchesPath("test/foo.js"))
+	// You can test the ignoreObject against various paths using the
+	// "MatchesPath()" interface method. This pretty much is up to
+	// the users interpretation. In the case of a ".gitignore" file,
+	// a "match" would indicate that a given path would be ignored.
+	fmt.Println(ignoreObject.MatchesPath("node_modules/test/foo.js"))
+	fmt.Println(ignoreObject.MatchesPath("node_modules2/test.out"))
+	fmt.Println(ignoreObject.MatchesPath("test/foo.js"))
 
-    // Output:
-    // true
-    // true
-    // false
+	// Output:
+	// true
+	// true
+	// false
 }
 
 func TestCompileIgnoreLines_CheckNestedDotFiles(test *testing.T) {
-    lines := []string{
-        "**/external/**/*.md",
-        "**/external/**/*.json",
-        "**/external/**/*.gzip",
-        "**/external/**/.*ignore",
+	lines := []string{
+		"**/external/**/*.md",
+		"**/external/**/*.json",
+		"**/external/**/*.gzip",
+		"**/external/**/.*ignore",
 
-        "**/external/foobar/*.css",
-        "**/external/barfoo/less",
-        "**/external/barfoo/scss",
-    }
-    object, error := CompileIgnoreLines(lines...)
-    assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
-    assert.NotNil(test, object, "returned object should not be nil")
+		"**/external/foobar/*.css",
+		"**/external/barfoo/less",
+		"**/external/barfoo/scss",
+	}
+	object, error := CompileIgnoreLines(lines...)
+	assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
+	assert.NotNil(test, object, "returned object should not be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("external/foobar/angular.foo.css"), "external/foobar/angular.foo.css")
-    assert.Equal(test, true,  object.MatchesPath("external/barfoo/.gitignore"), "external/barfoo/.gitignore")
-    assert.Equal(test, true,  object.MatchesPath("external/barfoo/.bower.json"), "external/barfoo/.bower.json")
+	assert.Equal(test, true, object.MatchesPath("external/foobar/angular.foo.css"), "external/foobar/angular.foo.css")
+	assert.Equal(test, true, object.MatchesPath("external/barfoo/.gitignore"), "external/barfoo/.gitignore")
+	assert.Equal(test, true, object.MatchesPath("external/barfoo/.bower.json"), "external/barfoo/.bower.json")
 }
 
 func TestCompileIgnoreLines_CarriageReturn(test *testing.T) {
-    lines := []string{"abc/def\r", "a/b/c\r", "b\r"}
-    object, error := CompileIgnoreLines(lines...)
-    assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
+	lines := []string{"abc/def\r", "a/b/c\r", "b\r"}
+	object, error := CompileIgnoreLines(lines...)
+	assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("abc/def/child"), "abc/def/child should match")
-    assert.Equal(test, true,  object.MatchesPath("a/b/c/d"),       "a/b/c/d should match")
+	assert.Equal(test, true, object.MatchesPath("abc/def/child"), "abc/def/child should match")
+	assert.Equal(test, true, object.MatchesPath("a/b/c/d"), "a/b/c/d should match")
 
-    assert.Equal(test, false, object.MatchesPath("abc"), "abc should not match")
-    assert.Equal(test, false, object.MatchesPath("def"), "def should not match")
-    assert.Equal(test, false, object.MatchesPath("bd"),  "bd should not match")
+	assert.Equal(test, false, object.MatchesPath("abc"), "abc should not match")
+	assert.Equal(test, false, object.MatchesPath("def"), "def should not match")
+	assert.Equal(test, false, object.MatchesPath("bd"), "bd should not match")
 }
 
 func TestCompileIgnoreLines_WindowsPath(test *testing.T) {
-    if runtime.GOOS != "windows" {
-        return
-    }
-    lines := []string{"abc/def", "a/b/c", "b"}
-    object, error := CompileIgnoreLines(lines...)
-    assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
+	if runtime.GOOS != "windows" {
+		return
+	}
+	lines := []string{"abc/def", "a/b/c", "b"}
+	object, error := CompileIgnoreLines(lines...)
+	assert.Nil(test, error, "error from CompileIgnoreLines should be nil")
 
-    assert.Equal(test, true,  object.MatchesPath("abc\\def\\child"), "abc\\def\\child should match")
-    assert.Equal(test, true,  object.MatchesPath("a\\b\\c\\d"),       "a\\b\\c\\d should match")
+	assert.Equal(test, true, object.MatchesPath("abc\\def\\child"), "abc\\def\\child should match")
+	assert.Equal(test, true, object.MatchesPath("a\\b\\c\\d"), "a\\b\\c\\d should match")
+}
+
+func TestWildCardFiles(test *testing.T) {
+	gitIgnore := []string{"*.swp", "/foo/*.wat", "bar/*.txt"}
+	object, err := CompileIgnoreLines(gitIgnore...)
+	assert.Nil(test, err, "error from CompileIgnoreLines should be nil")
+
+	// Paths which are targeted by the above "lines"
+	assert.Equal(test, true, object.MatchesPath("yo.swp"), "should ignore all swp files")
+	assert.Equal(test, true, object.MatchesPath("something/else/but/it/hasyo.swp"), "should ignore all swp files in other directories")
+
+	assert.Equal(test, true, object.MatchesPath("foo/bar.wat"), "should ignore all wat files in foo - nonpreceding /")
+	assert.Equal(test, true, object.MatchesPath("/foo/something.wat"), "should ignore all wat files in foo - preceding /")
+
+	assert.Equal(test, true, object.MatchesPath("bar/something.txt"), "should ignore all txt files in bar - nonpreceding /")
+	assert.Equal(test, true, object.MatchesPath("/bar/somethingelse.txt"), "should ignore all txt files in bar - preceding /")
+
+	// Paths which are not targeted by the above "lines"
+	assert.Equal(test, false, object.MatchesPath("something/not/infoo/wat.wat"), "wat files should only be ignored in foo")
+	assert.Equal(test, false, object.MatchesPath("something/not/infoo/wat.txt"), "txt files should only be ignored in bar")
 }


### PR DESCRIPTION
Right now this parse doesn't account for the `*` operator when there is a preceding `/` for a directory. 

For example, if you have `/foo/*.bar` in your `.gitignore` file it should ignore both the `/foo/yo.bar` and `foo/something.bar` paths, but right now the parser only ignores `/foo/yo.bar`. 

If there is not a preceding `/` for a directory, like in this example:
`bar/*.txt`

both `bar/something.txt` and `/bar/somethingelse.txt` are blocked

So this also makes the behavior a little more consistent